### PR TITLE
feat: 共有UIコンポーネントのCPU対戦対応

### DIFF
--- a/web/features/room/components/InstructionMessage.tsx
+++ b/web/features/room/components/InstructionMessage.tsx
@@ -9,13 +9,16 @@ type InstructionMessageProps = {
   };
   round: Round | undefined;
   userId: string | null;
+  opponentLabel?: string;
 };
 
 export function InstructionMessage({
   playerOperation,
   round,
   userId,
+  opponentLabel,
 }: InstructionMessageProps) {
+  const label = opponentLabel ?? "相手";
   const getInstruction = () => {
     if (playerOperation.setElectricShock) {
       return "電流を仕掛ける椅子を選んでください";
@@ -25,10 +28,10 @@ export function InstructionMessage({
     }
     if (playerOperation.wait) {
       if (round?.phase === "setting") {
-        return "相手が電流を仕掛けています。。。";
+        return `${label}が電流を仕掛けています。。。`;
       }
       if (round?.phase === "sitting") {
-        return "相手が座る椅子を選んでいます。。。";
+        return `${label}が座る椅子を選んでいます。。。`;
       }
       if (round?.phase === "activating") {
         if (round?.attackerId === userId) {

--- a/web/features/room/components/PlayerStatus.tsx
+++ b/web/features/room/components/PlayerStatus.tsx
@@ -4,11 +4,12 @@ import { Skull } from "lucide-react";
 type PlayerStatusProps = {
   userId: string | null;
   status: Player | undefined;
+  opponentLabel?: string;
 };
 
-export function PlayerStatus({ userId, status }: PlayerStatusProps) {
+export function PlayerStatus({ userId, status, opponentLabel }: PlayerStatusProps) {
   const playerStatus = status;
-  const playerName = status?.id === userId ? "あなた" : "相手";
+  const playerName = status?.id === userId ? "あなた" : (opponentLabel ?? "相手");
 
   return (
     <div className="p-6 bg-gray-700 text-center rounded-lg">

--- a/web/features/room/components/dialogs/TurnResultDialog.tsx
+++ b/web/features/room/components/dialogs/TurnResultDialog.tsx
@@ -9,6 +9,7 @@ type TurnResultDialogProps = {
   previousRoomData: GameRoom;
   userId: string;
   close: () => void;
+  opponentLabel?: string;
 };
 
 export function TurnResultDialog({
@@ -17,6 +18,7 @@ export function TurnResultDialog({
   previousRoomData,
   userId,
   close,
+  opponentLabel,
 }: TurnResultDialogProps) {
   const isAttacker = roomData?.round?.attackerId === userId;
   const isShocked = roomData?.round?.result.status === "shocked";
@@ -78,7 +80,7 @@ export function TurnResultDialog({
             </div>
           </div>
           <p className="pt-1 text-xl font-semibold text-gray-300">
-            {roomData?.round?.attackerId === userId ? "あなたの" : "相手の"}
+            {roomData?.round?.attackerId === userId ? "あなたの" : `${opponentLabel ?? "相手"}の`}
             スコアが更新されました
           </p>
           <div className="flex gap-8">

--- a/web/features/room/hooks/useRoomPhaseHandlers.ts
+++ b/web/features/room/hooks/useRoomPhaseHandlers.ts
@@ -23,11 +23,13 @@ function handleSettingPhase(
 
 function handleSittingPhase(
   showNoticeModal: ShowNoticeModalFn,
-  closeNoticeModal: () => void
+  closeNoticeModal: () => void,
+  opponentLabel?: string
 ) {
+  const label = opponentLabel ?? "相手";
   showNoticeModal(
     {
-      title: "相手が電気椅子を仕掛けました",
+      title: `${label}が電気椅子を仕掛けました`,
       message: "座る椅子を選択してください",
       button: { label: "OK", action: () => closeNoticeModal() },
     },
@@ -37,10 +39,12 @@ function handleSittingPhase(
 
 function handleActivatingPhase(
   showNoticeModal: ShowNoticeModalFn,
-  submitActivate: () => void
+  submitActivate: () => void,
+  opponentLabel?: string
 ) {
+  const label = opponentLabel ?? "相手";
   showNoticeModal({
-    title: "相手が椅子に座りました",
+    title: `${label}が椅子に座りました`,
     message: "電流を起動してください",
     button: { label: "起動", action: () => submitActivate() },
   });


### PR DESCRIPTION
## Summary
- `PlayerStatus`, `InstructionMessage`, `TurnResultDialog`, `useRoomPhaseHandlers` に `opponentLabel` props を追加
- CPU対戦時に「相手」→ CPU表示名（例: "ヒヨリ"）に動的切替可能
- 全て optional props のため、既存の対人戦コードに影響なし

## Test plan
- [ ] 対人戦で従来通り「相手」と表示されること
- [ ] `opponentLabel` を渡した場合、各コンポーネントで表示名が切り替わること
- [ ] `useRoomPhaseHandlers` の通知メッセージが表示名に切り替わること

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)