### PR TITLE
feat: トップ画面のセクション分けとCPU対戦ボタン追加

### DIFF
--- a/web/features/top/components/TopOperations.tsx
+++ b/web/features/top/components/TopOperations.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Button } from "@/components/buttons/Button";
 
 type TopOperationsProps = {
@@ -7,17 +8,32 @@ type TopOperationsProps = {
 
 export function TopOperations({ formAction, joinAction }: TopOperationsProps) {
   return (
-    <div className="flex flex-col gap-4 space-y-1.5 p-6 pt-0">
-      <form action={formAction} className="flex flex-col gap-4">
-        <Button>ルームを作成</Button>
-        <Button
-          type="button"
-          onClick={() => joinAction()}
-          bgColor="bg-gray-600"
-        >
-          ルームに入室
-        </Button>
-      </form>
+    <div className="flex flex-col gap-6 p-6 pt-0">
+      <section className="flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-500">ひとりで遊ぶ</span>
+          <div className="flex-1 border-t border-gray-600" />
+        </div>
+        <Link href="/cpu">
+          <Button type="button">CPU対戦</Button>
+        </Link>
+      </section>
+      <section className="flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-500">オンライン対戦</span>
+          <div className="flex-1 border-t border-gray-600" />
+        </div>
+        <form action={formAction} className="flex flex-col gap-3">
+          <Button>ルームを作成</Button>
+          <Button
+            type="button"
+            onClick={() => joinAction()}
+            bgColor="bg-gray-600"
+          >
+            ルームに入室
+          </Button>
+        </form>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- トップ画面を「ひとりで遊ぶ」「オンライン対戦」の2セクションに分割
- 「ひとりで遊ぶ」セクションにCPU対戦ボタンを追加（`/cpu` に遷移）
- セクションラベル（`text-gray-500`、区切り線付き）で意図を明確化

## Test plan
- [ ] CPU対戦ボタン押下で `/cpu` に遷移すること
- [ ] 既存の「ルームを作成」「ルームに入室」ボタンが変わらず動作すること
- [ ] セクションラベルと区切り線が正しく表示されること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)