### PR TITLE
CPU対戦: ゲーム状態管理と自動応答hookの実装

### DIFF
--- a/web/features/cpu-room/hooks/useCpuAutoPlay.ts
+++ b/web/features/cpu-room/hooks/useCpuAutoPlay.ts
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from "react";
+import type { CpuGameRoom, CpuPersonality } from "@/types/room";
+import type { CpuGameAction } from "@/features/cpu-room/hooks/useCpuGame";
+import {
+  selectChairAsAttacker,
+  selectChairAsDefender,
+  type AIContext,
+} from "@/features/cpu-room/logic/cpuPlayer";
+
+const CPU_ID = "cpu";
+
+const ACTIVATE_DELAY_MIN = 800;
+const ACTIVATE_DELAY_MAX = 1500;
+
+type UseCpuAutoPlayProps = {
+  gameRoom: CpuGameRoom;
+  dispatch: React.Dispatch<CpuGameAction>;
+  personality: CpuPersonality;
+};
+
+export function useCpuAutoPlay({
+  gameRoom,
+  dispatch,
+  personality,
+}: UseCpuAutoPlayProps) {
+  const historyRef = useRef<{ electricChairs: number[]; seatedChairs: number[] }>({
+    electricChairs: [],
+    seatedChairs: [],
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 履歴をresultフェーズで更新
+  useEffect(() => {
+    if (gameRoom.round.phase !== "result") return;
+    const { electricChair, seatedChair } = gameRoom.round;
+    const history = historyRef.current;
+    if (
+      electricChair !== null &&
+      history.electricChairs[history.electricChairs.length - 1] !== electricChair
+    ) {
+      history.electricChairs.push(electricChair);
+    }
+    if (
+      seatedChair !== null &&
+      history.seatedChairs[history.seatedChairs.length - 1] !== seatedChair
+    ) {
+      history.seatedChairs.push(seatedChair);
+    }
+  }, [gameRoom.round]);
+
+  // CPUのターン検知と自動応答
+  useEffect(() => {
+    const { round, players } = gameRoom;
+    const isCpuAttacker = round.attackerId === CPU_ID;
+    const isCpuDefender = round.attackerId !== CPU_ID;
+
+    const cpuPlayer = players.find((p) => p.id === CPU_ID);
+    const playerObj = players.find((p) => p.id !== CPU_ID);
+    if (!cpuPlayer || !playerObj) return;
+
+    const buildContext = (): AIContext => ({
+      personality,
+      remainingChairs: gameRoom.remainingChairs,
+      myPoint: cpuPlayer.point,
+      opponentPoint: playerObj.point,
+      myShockedCount: cpuPlayer.shockedCount,
+      opponentShockedCount: playerObj.shockedCount,
+      roundCount: round.count,
+      history: { ...historyRef.current },
+    });
+
+    // CPUが守備側: settingフェーズで電気椅子を設置
+    if (round.phase === "setting" && isCpuDefender) {
+      const ctx = buildContext();
+      const decision = selectChairAsDefender(ctx);
+      timerRef.current = setTimeout(() => {
+        dispatch({ type: "SELECT_ELECTRIC_CHAIR", chair: decision.selectedChair });
+      }, decision.thinkingTimeMs);
+      return;
+    }
+
+    // CPUが攻撃側: sittingフェーズで座る椅子を選択
+    if (round.phase === "sitting" && isCpuAttacker) {
+      const ctx = buildContext();
+      const decision = selectChairAsAttacker(ctx);
+      timerRef.current = setTimeout(() => {
+        dispatch({ type: "SELECT_SEATED_CHAIR", chair: decision.selectedChair });
+      }, decision.thinkingTimeMs);
+      return;
+    }
+
+    // CPUが守備側: activatingフェーズで電流を起動
+    if (round.phase === "activating" && isCpuDefender) {
+      const delay =
+        ACTIVATE_DELAY_MIN +
+        Math.random() * (ACTIVATE_DELAY_MAX - ACTIVATE_DELAY_MIN);
+      timerRef.current = setTimeout(() => {
+        dispatch({ type: "ACTIVATE" });
+      }, delay);
+      return;
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [gameRoom.round.phase, gameRoom.round.attackerId, dispatch, personality, gameRoom]);
+}

--- a/web/features/cpu-room/hooks/useCpuGame.ts
+++ b/web/features/cpu-room/hooks/useCpuGame.ts
@@ -1,0 +1,100 @@
+import { useReducer } from "react";
+import {
+  CpuGameRoom,
+  CpuPersonality,
+  CPU_DISPLAY_NAMES,
+  GameRoom,
+} from "@/types/room";
+import { plainRoundData } from "@/utils/room";
+import { applyActivation, applyChangeTurn } from "@/features/room/logic/gameLogic";
+
+// ─── Action型 ───
+
+export type CpuGameAction =
+  | { type: "SELECT_ELECTRIC_CHAIR"; chair: number }
+  | { type: "SELECT_SEATED_CHAIR"; chair: number }
+  | { type: "ACTIVATE" }
+  | { type: "SHOW_RESULT" }
+  | { type: "CHANGE_TURN" };
+
+// ─── Reducer ───
+
+export function cpuGameReducer(
+  state: CpuGameRoom,
+  action: CpuGameAction
+): CpuGameRoom {
+  switch (action.type) {
+    case "SELECT_ELECTRIC_CHAIR":
+      return {
+        ...state,
+        round: {
+          ...state.round,
+          electricChair: action.chair,
+          phase: "sitting",
+        },
+      };
+    case "SELECT_SEATED_CHAIR":
+      return {
+        ...state,
+        round: {
+          ...state.round,
+          seatedChair: action.chair,
+          phase: "activating",
+        },
+      };
+    case "ACTIVATE":
+      return applyActivation(state) as CpuGameRoom;
+    case "SHOW_RESULT":
+      return {
+        ...state,
+        round: {
+          ...state.round,
+          result: {
+            ...state.round.result,
+            shownResult: true,
+          },
+        },
+      };
+    case "CHANGE_TURN":
+      return applyChangeTurn(state) as CpuGameRoom;
+  }
+}
+
+// ─── 初期状態生成 ───
+
+const PLAYER_ID = "player";
+const CPU_ID = "cpu";
+
+export function createInitialCpuRoom(personality: CpuPersonality): CpuGameRoom {
+  const baseRoom: GameRoom = {
+    createrId: PLAYER_ID,
+    status: "inProgress",
+    players: [
+      { id: PLAYER_ID, point: 0, shockedCount: 0, ready: true },
+      { id: CPU_ID, point: 0, shockedCount: 0, ready: true },
+    ],
+    round: {
+      ...plainRoundData.round,
+      attackerId: PLAYER_ID,
+    },
+    remainingChairs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    winnerId: null,
+  };
+
+  return {
+    ...baseRoom,
+    cpuDisplayName: CPU_DISPLAY_NAMES[personality],
+  };
+}
+
+// ─── Hook ───
+
+export function useCpuGame(personality: CpuPersonality) {
+  const [gameRoom, dispatch] = useReducer(
+    cpuGameReducer,
+    personality,
+    createInitialCpuRoom
+  );
+
+  return { gameRoom, dispatch };
+}

--- a/web/features/cpu-room/hooks/useCpuRoomActions.ts
+++ b/web/features/cpu-room/hooks/useCpuRoomActions.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from "react";
+import type { CpuGameAction } from "@/features/cpu-room/hooks/useCpuGame";
+import type { PlayerOperation } from "@/features/room/hooks/usePlayerOperation";
+
+type UseCpuRoomActionsProps = {
+  dispatch: React.Dispatch<CpuGameAction>;
+  playerOperation: PlayerOperation;
+};
+
+export function useCpuRoomActions({
+  dispatch,
+  playerOperation,
+}: UseCpuRoomActionsProps) {
+  const [selectedChair, setSelectedChair] = useState<number | null>(null);
+
+  const selectChair = useCallback(() => {
+    if (selectedChair === null) return;
+
+    if (playerOperation.setElectricShock) {
+      dispatch({ type: "SELECT_ELECTRIC_CHAIR", chair: selectedChair });
+    } else if (playerOperation.selectSitChair) {
+      dispatch({ type: "SELECT_SEATED_CHAIR", chair: selectedChair });
+    }
+  }, [selectedChair, playerOperation, dispatch]);
+
+  const submitActivate = useCallback(
+    (onBeforeActivate?: () => void) => {
+      onBeforeActivate?.();
+      dispatch({ type: "ACTIVATE" });
+    },
+    [dispatch]
+  );
+
+  const changeTurn = useCallback(
+    (onBeforeChange?: () => void) => {
+      onBeforeChange?.();
+      dispatch({ type: "SHOW_RESULT" });
+      dispatch({ type: "CHANGE_TURN" });
+    },
+    [dispatch]
+  );
+
+  return {
+    selectedChair,
+    setSelectedChair,
+    selectChair,
+    submitActivate,
+    changeTurn,
+  };
+}


### PR DESCRIPTION
## Summary
- `useCpuGame`: `useReducer`によるローカルゲーム状態管理、`cpuGameReducer`の実装、`createInitialCpuRoom`による初期状態生成
- `useCpuRoomActions`: dispatch版アクション（`useRoomActions`のCPU対戦版）。椅子選択・電流起動・ターン遷移をdispatchで実行
- `useCpuAutoPlay`: CPUのターンを検知してsetTimeoutで自動応答。遅延時間は仕様通り（電気椅子設置/座る椅子: 1.5〜3秒、電流起動: 0.8〜1.5秒）

## Test plan
- [x] 型チェック（`tsc --noEmit`）がパスすること

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)