### PR TITLE
CPU対戦ページの実装 (/cpu)

### DIFF
--- a/web/app/cpu/page.tsx
+++ b/web/app/cpu/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import CpuRoom from "@/features/cpu-room/page/CpuRoom";
+
+export default function CpuPage() {
+  return <CpuRoom />;
+}

--- a/web/features/cpu-room/page/CpuRoom.tsx
+++ b/web/features/cpu-room/page/CpuRoom.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import useSound from "use-sound";
+
+import { useToast } from "@/utils/toast/useToast";
+import { getOpponentLabel } from "@/utils/room";
+
+import { Chair } from "@/features/room/components/Chair";
+import { PlayerStatus } from "@/features/room/components/PlayerStatus";
+import { RoundStatus } from "@/features/room/components/RoundStatus";
+import { StartTurnDialog } from "@/features/room/components/dialogs/StartTurnDialog";
+import { GameResultDialog } from "@/features/room/components/dialogs/GameResultDialog";
+import { TurnResultDialog } from "@/features/room/components/dialogs/TurnResultDialog";
+
+import { InstructionMessage } from "@/features/room/components/InstructionMessage";
+import { ActivateEffect } from "@/features/room/components/ActivateEffect";
+import { RoomContainer } from "@/features/room/components/RoomContainer";
+import { GameStatusContainer } from "@/features/room/components/GameStatusContainer";
+import { ChairContainer } from "@/features/room/components/ChairContainer";
+import { InstructionContainer } from "@/features/room/components/InstructionContainer";
+import { PlayerStatusContainer } from "@/features/room/components/PlayerStatusContainer";
+import { Button } from "@/components/buttons/Button";
+import { NoticeDialog } from "@/components/dialogs/notice/NoticeDailog";
+import { useRoomDialogs } from "@/features/room/hooks/useRoomDialogs";
+import { usePlayerOperation } from "@/features/room/hooks/usePlayerOperation";
+import { useRoomEffect } from "@/features/room/hooks/useRoomEffect";
+
+import { useCpuGame } from "@/features/cpu-room/hooks/useCpuGame";
+import { useCpuAutoPlay } from "@/features/cpu-room/hooks/useCpuAutoPlay";
+import { useCpuRoomActions } from "@/features/cpu-room/hooks/useCpuRoomActions";
+import {
+  pickRandomPersonality,
+  resetTricksterState,
+} from "@/features/cpu-room/logic/cpuPlayer";
+import type { CpuPersonality } from "@/types/room";
+
+const PLAYER_ID = "player";
+const SESSION_KEY = "cpuLastPersonality";
+
+function getInitialPersonality(): CpuPersonality {
+  if (typeof window === "undefined") return pickRandomPersonality();
+  const prev = sessionStorage.getItem(SESSION_KEY) as CpuPersonality | null;
+  return pickRandomPersonality(prev ?? undefined);
+}
+
+export default function CpuRoom() {
+  const [personality, setPersonality] = useState<CpuPersonality>(getInitialPersonality);
+  const [gameKey, setGameKey] = useState(0);
+
+  useEffect(() => {
+    sessionStorage.setItem(SESSION_KEY, personality);
+  }, [personality]);
+
+  const handleRetry = () => {
+    resetTricksterState();
+    const newPersonality = pickRandomPersonality(personality);
+    setPersonality(newPersonality);
+    setGameKey((k) => k + 1);
+  };
+
+  return (
+    <CpuRoomInner
+      key={gameKey}
+      personality={personality}
+      onRetry={handleRetry}
+    />
+  );
+}
+
+function CpuRoomInner({
+  personality,
+  onRetry,
+}: {
+  personality: CpuPersonality;
+  onRetry: () => void;
+}) {
+  const [playShockEffect] = useSound("/sounds/shock.mp3");
+  const [playSafeEffect] = useSound("/sounds/safe.mp3");
+  const router = useRouter();
+  const toast = useToast();
+
+  const { gameRoom, dispatch } = useCpuGame(personality);
+  const [showShock, setShowShock] = useState<"" | "shock" | "safe">("");
+  const previousRoomDataRef = useRef(gameRoom);
+
+  // activatingフェーズに入ったら、その時点のstateをpreviousとして保存
+  // (result遷移後のTurnResultDialogでスコア変化前後を表示するため)
+  useEffect(() => {
+    if (gameRoom.round.phase === "activating") {
+      previousRoomDataRef.current = gameRoom;
+    }
+  }, [gameRoom, gameRoom.round.phase]);
+
+  const opponentLabel = getOpponentLabel(gameRoom);
+
+  const {
+    NoticeDialogRef,
+    noticeDialogState,
+    showNoticeModal,
+    closeNoticeModal,
+    waitingCreaterStartDialogRef: _waitingRef,
+    showCreaterWaitingStartModal,
+    closeCreaterWaitingStartModal,
+    startTurnDialogRef,
+    showStartTurnModal,
+    turnResultDialogRef,
+    showTurnResultModal,
+    closeTurnResultModal,
+    gameResultDialogRef,
+    showGameResultModal,
+  } = useRoomDialogs();
+
+  const playerOperation = usePlayerOperation(gameRoom, PLAYER_ID);
+
+  useCpuAutoPlay({ gameRoom, dispatch, personality });
+
+  const { selectedChair, setSelectedChair, selectChair, submitActivate, changeTurn } =
+    useCpuRoomActions({ dispatch, playerOperation });
+
+  const handleSubmitActivate = () => {
+    submitActivate(closeNoticeModal);
+  };
+
+  const handleChangeTurn = () => {
+    changeTurn(() => {
+      closeTurnResultModal();
+      setSelectedChair(null);
+    });
+  };
+
+  const isAllReady = () => true;
+
+  const toTop = () => {
+    router.push("/");
+  };
+
+  useRoomEffect({
+    roomData: gameRoom,
+    userId: PLAYER_ID,
+    isAllReady,
+    setShowShock,
+    showCreaterWaitingStartModal,
+    closeCreaterWaitingStartModal,
+    showStartTurnModal,
+    showNoticeModal,
+    closeNoticeModal,
+    handleSubmitActivate,
+    playShockEffect,
+    playSafeEffect,
+    showGameResultModal,
+    showTurnResultModal,
+    opponentLabel,
+  });
+
+  const handleSelectChair = () => {
+    if (selectedChair === null) return;
+    toast.open(
+      <span>
+        <span style={{ color: "red", fontWeight: "bold", fontSize: "1.2rem" }}>
+          {selectedChair}
+        </span>
+        番の椅子を選択しました。
+      </span>
+    );
+    selectChair();
+  };
+
+  return (
+    <RoomContainer>
+      <GameStatusContainer>
+        <RoundStatus round={gameRoom.round} userId={PLAYER_ID} />
+        <PlayerStatusContainer>
+          <PlayerStatus
+            userId={PLAYER_ID}
+            status={gameRoom.players.find((player) => player.id === PLAYER_ID)}
+          />
+          <PlayerStatus
+            userId={PLAYER_ID}
+            status={gameRoom.players.find((player) => player.id !== PLAYER_ID)}
+            opponentLabel={opponentLabel}
+          />
+        </PlayerStatusContainer>
+      </GameStatusContainer>
+      <div>
+        <ChairContainer>
+          {gameRoom.remainingChairs.map((chair) => (
+            <Chair
+              key={chair}
+              chair={chair}
+              setSelectedChair={setSelectedChair}
+              wait={playerOperation.wait}
+              selected={selectedChair === chair}
+            />
+          ))}
+          <InstructionContainer>
+            <InstructionMessage
+              playerOperation={playerOperation}
+              round={gameRoom.round}
+              userId={PLAYER_ID}
+              opponentLabel={opponentLabel}
+            />
+          </InstructionContainer>
+        </ChairContainer>
+        {!playerOperation.wait &&
+          !playerOperation.activate &&
+          selectedChair && (
+            <div className="sticky bottom-3">
+              <Button
+                type="button"
+                onClick={handleSelectChair}
+                styles="border-2 border-red-700"
+              >
+                確定
+              </Button>
+            </div>
+          )}
+      </div>
+      <NoticeDialog
+        dialogRef={NoticeDialogRef}
+        title={noticeDialogState.title}
+        message={noticeDialogState.message}
+        button={noticeDialogState.button}
+      />
+      <StartTurnDialog
+        dialogRef={startTurnDialogRef}
+        round={gameRoom.round}
+        userId={PLAYER_ID}
+      />
+      <TurnResultDialog
+        ref={turnResultDialogRef}
+        roomData={gameRoom}
+        previousRoomData={previousRoomDataRef.current}
+        userId={PLAYER_ID}
+        close={handleChangeTurn}
+        opponentLabel={opponentLabel}
+      />
+      <GameResultDialog
+        ref={gameResultDialogRef}
+        roomData={gameRoom}
+        userId={PLAYER_ID}
+        close={toTop}
+        onRetry={onRetry}
+        opponentLabel={opponentLabel}
+      />
+      <ActivateEffect result={showShock} />
+    </RoomContainer>
+  );
+}

--- a/web/features/room/components/dialogs/GameResultDialog.tsx
+++ b/web/features/room/components/dialogs/GameResultDialog.tsx
@@ -8,6 +8,8 @@ type GameResultDialogProps = {
   roomData: GameRoom;
   userId: string;
   close: () => void;
+  onRetry?: () => void;
+  opponentLabel?: string;
 };
 
 export function GameResultDialog({
@@ -15,6 +17,8 @@ export function GameResultDialog({
   roomData,
   userId,
   close,
+  onRetry,
+  opponentLabel,
 }: GameResultDialogProps) {
   const isWinner = roomData?.winnerId === userId;
   const isDraw = roomData?.winnerId === "draw";
@@ -42,22 +46,23 @@ export function GameResultDialog({
 
   const getWinningCondition = () => {
     if (opponentStatus === undefined || myStatus === undefined) return "";
+    const label = opponentLabel ?? "相手";
     if (isWinner) {
       if (myStatus!.point >= 40) {
         return "40ポイント以上獲得しました";
       } else if (opponentStatus!.shockedCount === 3) {
-        return "相手が3回感電しました";
+        return `${label}が3回感電しました`;
       }
       return "獲得ポイントで上回りました";
     } else if (isDraw) {
       return "合計獲得ポイントが同じでした";
     } else {
       if (opponentStatus!.point >= 40) {
-        return "相手が40ポイント以上獲得しました";
+        return `${label}が40ポイント以上獲得しました`;
       } else if (myStatus!.shockedCount === 3) {
         return "3回感電しました";
       }
-      return "相手が獲得ポイントで上回りました";
+      return `${label}が獲得ポイントで上回りました`;
     }
   };
 
@@ -97,7 +102,7 @@ export function GameResultDialog({
               </div>
             </div>
             <div className="flex flex-col items-center">
-              <div className="text-white font-bold text-md">相手のスコア</div>
+              <div className="text-white font-bold text-md">{opponentLabel ?? "相手"}のスコア</div>
               <div className="text-gray-400">獲得ポイント</div>
               <div className="font-bold text-green-500 text-4xl">
                 {opponentStatus?.point}
@@ -109,9 +114,20 @@ export function GameResultDialog({
             </div>
           </div>
         </div>
-        <Button onClick={close} bgColor={bgColor}>
-          ゲーム終了
-        </Button>
+        {onRetry ? (
+          <div className="flex flex-col gap-2 w-full">
+            <Button onClick={onRetry} bgColor={bgColor}>
+              もういちど
+            </Button>
+            <Button onClick={close} bgColor="bg-gray-600">
+              トップにもどる
+            </Button>
+          </div>
+        ) : (
+          <Button onClick={close} bgColor={bgColor}>
+            ゲーム終了
+          </Button>
+        )}
       </div>
     </dialog>
   );

--- a/web/features/room/hooks/useRoomEffect.ts
+++ b/web/features/room/hooks/useRoomEffect.ts
@@ -18,6 +18,7 @@ export function useRoomEffect({
   playSafeEffect,
   showGameResultModal,
   showTurnResultModal,
+  opponentLabel,
 }: {
   roomData: GameRoom | null;
   userId: string;
@@ -33,6 +34,7 @@ export function useRoomEffect({
   playSafeEffect: () => void;
   showGameResultModal: () => void;
   showTurnResultModal: () => void;
+  opponentLabel?: string;
 }) {
   useEffect(() => {
     if (!roomData) return;
@@ -60,13 +62,14 @@ export function useRoomEffect({
       }
 
       if (roomData.round.phase === "sitting" && isAttacker) {
-        RoomPhaseHandlers.handleSittingPhase(showNoticeModal, closeNoticeModal);
+        RoomPhaseHandlers.handleSittingPhase(showNoticeModal, closeNoticeModal, opponentLabel);
       }
     }
     if (roomData.round.phase === "activating" && isDefender) {
       RoomPhaseHandlers.handleActivatingPhase(
         showNoticeModal,
-        handleSubmitActivate
+        handleSubmitActivate,
+        opponentLabel
       );
     }
     if (


### PR DESCRIPTION
## Summary
- `app/cpu/page.tsx`: CPU対戦ページ（`"use client"`で完結、Cookie/middleware不要）
- `features/cpu-room/page/CpuRoom.tsx`: CPU対戦メインコンポーネント
  - 性格のランダム選択と連続同性格回避（`sessionStorage`で前回性格を記憶）
  - `useCpuGame` + `useCpuAutoPlay` + `useCpuRoomActions` を統合接続
  - `usePlayerOperation`, `useRoomEffect`, `useRoomDialogs` をそのまま再利用
  - activatingフェーズのCPU自動処理（CPUが守備側のとき0.8〜1.5秒後に自動起動）
  - 「もういちど」ボタンで新しい性格のCPUと即再戦
- `GameResultDialog`: CPU対戦時に「もういちど」「トップにもどる」の2ボタン表示、表示名対応
- `useRoomEffect`: `opponentLabel`パラメータ追加で各フェーズハンドラにCPU表示名を伝播

## Test plan
- [x] `/cpu` にアクセスしてCPU対戦が開始されること
- [x] 先攻がプレイヤー固定であること
- [x] CPUが守備側のとき自動で電気椅子を設置すること
- [x] CPUが攻撃側のとき自動で座る椅子を選択すること
- [x] CPUが守備側のactivatingフェーズで自動起動すること
- [x] プレイヤーが守備側のactivatingフェーズで「起動」ボタンが表示されること
- [x] InstructionMessageにCPU表示名が正しく表示されること
- [x] TurnResultDialogにCPU表示名が正しく表示されること
- [x] GameResultDialogに「もういちど」「トップにもどる」ボタンが表示されること
- [x] 「もういちど」で新しいCPUと即再戦できること
- [x] 連続で同じ性格のCPUが選ばれないこと
- [x] 対人戦（`/room/[roomId]`）が既存通り動作すること

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)