### PR TITLE
TurnHistory型定義とCPU対戦の履歴蓄積ロジックを追加

### DIFF
--- a/web/features/cpu-room/hooks/useCpuGame.test.ts
+++ b/web/features/cpu-room/hooks/useCpuGame.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { cpuGameReducer, createInitialCpuRoom } from "@/features/cpu-room/hooks/useCpuGame";
+import type { CpuGameRoom } from "@/types/room";
+
+function withRound(state: CpuGameRoom, round: Partial<CpuGameRoom["round"]>): CpuGameRoom {
+  return {
+    ...state,
+    round: {
+      ...state.round,
+      ...round,
+    },
+  };
+}
+
+test("ACTIVATEでsafe結果の履歴が追加される", () => {
+  const initial = createInitialCpuRoom("chicken");
+  const state = withRound(initial, {
+    count: 2,
+    turn: "top",
+    attackerId: "player",
+    phase: "activating",
+    electricChair: 1,
+    seatedChair: 2,
+  });
+
+  const next = cpuGameReducer(state, { type: "ACTIVATE" });
+
+  assert.equal(next.history.length, 1);
+  assert.deepEqual(next.history[0], {
+    roundCount: 2,
+    turn: "top",
+    attackerId: "player",
+    electricChair: 1,
+    seatedChair: 2,
+    result: "safe",
+  });
+});
+
+test("感電時にスコアがリセットされても履歴が記録される", () => {
+  const initial = createInitialCpuRoom("analyst");
+  const withPoints: CpuGameRoom = {
+    ...initial,
+    players: initial.players.map((player) =>
+      player.id === "player" ? { ...player, point: 15, shockedCount: 0 } : player
+    ),
+    history: [
+      {
+        roundCount: 1,
+        turn: "top",
+        attackerId: "player",
+        electricChair: 4,
+        seatedChair: 5,
+        result: "safe",
+      },
+    ],
+  };
+  const state = withRound(withPoints, {
+    count: 2,
+    turn: "bottom",
+    attackerId: "player",
+    phase: "activating",
+    electricChair: 3,
+    seatedChair: 3,
+  });
+
+  const next = cpuGameReducer(state, { type: "ACTIVATE" });
+  const attacker = next.players.find((player) => player.id === "player");
+
+  assert.equal(attacker?.point, 0);
+  assert.equal(attacker?.shockedCount, 1);
+  assert.equal(next.history.length, 2);
+  assert.equal(next.history[1]?.result, "shocked");
+});
+
+test("winnerId確定ターンでも最終履歴が追加される", () => {
+  const initial = createInitialCpuRoom("hunter");
+  const prepared: CpuGameRoom = {
+    ...initial,
+    players: initial.players.map((player) =>
+      player.id === "player" ? { ...player, point: 39 } : player
+    ),
+    remainingChairs: [5],
+  };
+  const state = withRound(prepared, {
+    count: 3,
+    turn: "bottom",
+    attackerId: "player",
+    phase: "activating",
+    electricChair: 1,
+    seatedChair: 5,
+  });
+
+  const next = cpuGameReducer(state, { type: "ACTIVATE" });
+
+  assert.equal(next.winnerId, "player");
+  assert.equal(next.history.length, 1);
+  assert.deepEqual(next.history[0], {
+    roundCount: 3,
+    turn: "bottom",
+    attackerId: "player",
+    electricChair: 1,
+    seatedChair: 5,
+    result: "safe",
+  });
+});

--- a/web/features/cpu-room/hooks/useCpuGame.ts
+++ b/web/features/cpu-room/hooks/useCpuGame.ts
@@ -4,6 +4,7 @@ import {
   CpuPersonality,
   CPU_DISPLAY_NAMES,
   GameRoom,
+  TurnHistory,
 } from "@/types/room";
 import { plainRoundData } from "@/utils/room";
 import { applyActivation, applyChangeTurn } from "@/features/room/logic/gameLogic";
@@ -16,6 +17,32 @@ export type CpuGameAction =
   | { type: "ACTIVATE" }
   | { type: "SHOW_RESULT" }
   | { type: "CHANGE_TURN" };
+
+export function buildTurnHistoryEntry(
+  previousState: CpuGameRoom,
+  activatedState: CpuGameRoom
+): TurnHistory | null {
+  const result = activatedState.round.result.status;
+
+  if (
+    activatedState.round.phase !== "result" ||
+    previousState.round.phase === "result" ||
+    (result !== "shocked" && result !== "safe") ||
+    previousState.round.electricChair === null ||
+    previousState.round.seatedChair === null
+  ) {
+    return null;
+  }
+
+  return {
+    roundCount: previousState.round.count,
+    turn: previousState.round.turn,
+    attackerId: previousState.round.attackerId,
+    electricChair: previousState.round.electricChair,
+    seatedChair: previousState.round.seatedChair,
+    result,
+  };
+}
 
 // ─── Reducer ───
 
@@ -43,7 +70,15 @@ export function cpuGameReducer(
         },
       };
     case "ACTIVATE":
-      return applyActivation(state) as CpuGameRoom;
+      const activatedState = applyActivation(state) as CpuGameRoom;
+      const historyEntry = buildTurnHistoryEntry(state, activatedState);
+      if (!historyEntry) {
+        return activatedState;
+      }
+      return {
+        ...activatedState,
+        history: [...state.history, historyEntry],
+      };
     case "SHOW_RESULT":
       return {
         ...state,
@@ -84,6 +119,7 @@ export function createInitialCpuRoom(personality: CpuPersonality): CpuGameRoom {
   return {
     ...baseRoom,
     cpuDisplayName: CPU_DISPLAY_NAMES[personality],
+    history: [],
   };
 }
 

--- a/web/types/room.ts
+++ b/web/types/room.ts
@@ -49,8 +49,18 @@ export const CPU_DISPLAY_NAMES: Record<CpuPersonality, string> = {
   trickster: "イタズ",
 } as const;
 
+export type TurnHistory = {
+  roundCount: number;
+  turn: "top" | "bottom";
+  attackerId: string;
+  electricChair: number;
+  seatedChair: number;
+  result: "shocked" | "safe";
+};
+
 export type CpuGameRoom = GameRoom & {
   cpuDisplayName: string;
+  history: TurnHistory[];
 };
 
 export type RoomResponse =


### PR DESCRIPTION
## Summary
- `TurnHistory` 型を `web/types/room.ts` に追加
- `CpuGameRoom` に `history` を追加し、CPU対戦状態に履歴配列を保持
- `useCpuGame` の reducer `ACTIVATE` で `applyActivation` の結果から履歴エントリを構築して蓄積
- 履歴構築ロジックの単体テストを追加（safe / shocked / winner確定ターン）

## Test plan
- [x] `cd web && npx tsc --noEmit`
- [ ] `cd web && npm run lint`（現状のプロジェクト設定で `next lint` が `.../web/lint` をディレクトリ扱いし失敗）

Closes #27

🤖 Generated with Codex