### PR TITLE
feat: CPU対戦画面にヒストリーモーダルを追加

### DIFF
--- a/web/components/dialogs/InfoDialog.tsx
+++ b/web/components/dialogs/InfoDialog.tsx
@@ -12,6 +12,11 @@ export function InfoDialog({ ref, children, borderColor }: InfoDialogProps) {
     <dialog
       className="min-w-fit max-w-lg top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-transparent backdrop:bg-black/80 shadow-sm w-full"
       ref={ref}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          (e.currentTarget as HTMLDialogElement).close();
+        }
+      }}
     >
       <div
         className={`animate-scale-in grid gap-4 backdrop:bg-black/80 p-6 text-card-foreground shadow-sm w-full bg-gray-800 border-2 ${border}`}

--- a/web/features/cpu-room/page/CpuRoom.tsx
+++ b/web/features/cpu-room/page/CpuRoom.tsx
@@ -13,6 +13,7 @@ import { RoundStatus } from "@/features/room/components/RoundStatus";
 import { StartTurnDialog } from "@/features/room/components/dialogs/StartTurnDialog";
 import { GameResultDialog } from "@/features/room/components/dialogs/GameResultDialog";
 import { TurnResultDialog } from "@/features/room/components/dialogs/TurnResultDialog";
+import { HistoryDialog } from "@/features/room/components/dialogs/HistoryDialog";
 
 import { InstructionMessage } from "@/features/room/components/InstructionMessage";
 import { ActivateEffect } from "@/features/room/components/ActivateEffect";
@@ -36,6 +37,7 @@ import {
   resetTricksterState,
 } from "@/features/cpu-room/logic/cpuPlayer";
 import type { CpuPersonality } from "@/types/room";
+import { History } from "lucide-react";
 
 const PLAYER_ID = "player";
 const SESSION_KEY = "cpuLastPersonality";
@@ -86,6 +88,7 @@ function CpuRoomInner({
   useRecordCpuResult(gameRoom, personality);
   const [showShock, setShowShock] = useState<"" | "shock" | "safe">("");
   const previousRoomDataRef = useRef(gameRoom);
+  const historyDialogRef = useRef<HTMLDialogElement | null>(null);
 
   // activatingフェーズに入ったら、その時点のstateをpreviousとして保存
   // (result遷移後のTurnResultDialogでスコア変化前後を表示するため)
@@ -169,9 +172,27 @@ function CpuRoomInner({
     selectChair();
   };
 
+  const openHistoryDialog = () => {
+    historyDialogRef.current?.showModal();
+  };
+
+  const closeHistoryDialog = () => {
+    historyDialogRef.current?.close();
+  };
+
   return (
     <RoomContainer>
       <GameStatusContainer>
+        <div className="flex justify-end">
+          <div className="w-32">
+            <Button type="button" onClick={openHistoryDialog} bgColor="bg-sky-600">
+              <span className="inline-flex items-center gap-1">
+                <History className="h-4 w-4" />
+                ヒストリー
+              </span>
+            </Button>
+          </div>
+        </div>
         <RoundStatus round={gameRoom.round} userId={PLAYER_ID} />
         <PlayerStatusContainer>
           <PlayerStatus
@@ -244,6 +265,13 @@ function CpuRoomInner({
         userId={PLAYER_ID}
         close={toTop}
         onRetry={onRetry}
+        opponentLabel={opponentLabel}
+      />
+      <HistoryDialog
+        dialogRef={historyDialogRef}
+        history={gameRoom.history}
+        userId={PLAYER_ID}
+        close={closeHistoryDialog}
         opponentLabel={opponentLabel}
       />
       <ActivateEffect result={showShock} />

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -1,6 +1,7 @@
 import { InfoDialog } from "@/components/dialogs/InfoDialog";
 import { Button } from "@/components/buttons/Button";
 import { TurnHistory } from "@/types/room";
+import { Shield, Target, Zap } from "lucide-react";
 import { Ref } from "react";
 
 type HistoryDialogProps = {
@@ -35,26 +36,61 @@ export function HistoryDialog({
                 entry.attackerId === userId ? "自分" : opponentLabel ?? "相手";
               const seatedLabel =
                 entry.attackerId === userId ? opponentLabel ?? "相手" : "自分";
+              const strategyResult =
+                entry.result === "shocked"
+                  ? "電気を仕掛けた側の作戦成功"
+                  : "座った側の回避成功";
               return (
                 <li
                   key={`${entry.roundCount}-${entry.turn}-${index}`}
-                  className="rounded-md border border-gray-600 bg-gray-900/70 p-3 text-sm"
+                  className="rounded-md border border-gray-600 bg-gray-900/70 p-3"
                 >
-                  <div className="font-semibold text-gray-100">
-                    {entry.roundCount}回 {getTurnLabel(entry.turn)}
+                  <div className="flex items-center justify-between">
+                    <div className="font-semibold text-gray-100">
+                      {entry.roundCount}回 {getTurnLabel(entry.turn)}
+                    </div>
+                    <div
+                      className={`text-xs font-bold px-2 py-1 rounded-full ${
+                        entry.result === "shocked"
+                          ? "bg-red-500/20 text-red-300"
+                          : "bg-emerald-500/20 text-emerald-300"
+                      }`}
+                    >
+                      {strategyResult}
+                    </div>
                   </div>
-                  <div className="text-gray-300">
-                    電気を仕掛けた側: {attackerLabel} / 座った側: {seatedLabel}
+                  <div className="grid grid-cols-2 gap-2 mt-3 text-sm">
+                    <div className="rounded border border-orange-400/40 bg-orange-950/30 p-2">
+                      <div className="flex items-center gap-1 text-orange-300 font-semibold">
+                        <Zap className="h-4 w-4" />
+                        電気を仕掛けた側
+                      </div>
+                      <div className="text-white font-bold">{attackerLabel}</div>
+                      <div className="text-gray-300 text-xs mt-1">
+                        狙い: 椅子{entry.electricChair}
+                      </div>
+                    </div>
+                    <div className="rounded border border-sky-400/40 bg-sky-950/30 p-2">
+                      <div className="flex items-center gap-1 text-sky-300 font-semibold">
+                        <Shield className="h-4 w-4" />
+                        座った側
+                      </div>
+                      <div className="text-white font-bold">{seatedLabel}</div>
+                      <div className="text-gray-300 text-xs mt-1">
+                        選択: 椅子{entry.seatedChair}
+                      </div>
+                    </div>
                   </div>
-                  <div className="text-gray-300">
-                    電気椅子: {entry.electricChair} / 座った椅子: {entry.seatedChair}
-                  </div>
-                  <div
-                    className={`font-semibold ${
-                      entry.result === "shocked" ? "text-red-400" : "text-emerald-400"
-                    }`}
-                  >
-                    結果: {entry.result === "shocked" ? "感電" : "セーフ"}
+                  <div className="mt-2 flex items-center gap-2 text-sm text-gray-300">
+                    <Target className="h-4 w-4 text-gray-400" />
+                    結果:
+                    <span
+                      className={`font-semibold ${
+                        entry.result === "shocked" ? "text-red-400" : "text-emerald-400"
+                      }`}
+                    >
+                      {entry.result === "shocked" ? "感電" : "セーフ"}
+                    </span>
                   </div>
                 </li>
               );

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -1,0 +1,66 @@
+import { InfoDialog } from "@/components/dialogs/InfoDialog";
+import { Button } from "@/components/buttons/Button";
+import { TurnHistory } from "@/types/room";
+import { Ref } from "react";
+
+type HistoryDialogProps = {
+  dialogRef: Ref<HTMLDialogElement>;
+  history: TurnHistory[];
+  userId: string;
+  close: () => void;
+  opponentLabel?: string;
+};
+
+function getTurnLabel(turn: TurnHistory["turn"]) {
+  return turn === "top" ? "表" : "裏";
+}
+
+export function HistoryDialog({
+  dialogRef,
+  history,
+  userId,
+  close,
+  opponentLabel,
+}: HistoryDialogProps) {
+  return (
+    <InfoDialog ref={dialogRef} borderColor="border-sky-500">
+      <div className="grid gap-4">
+        <h2 className="text-2xl font-bold text-sky-400">ヒストリー</h2>
+        {history.length === 0 ? (
+          <p className="text-gray-300">まだ履歴はありません。</p>
+        ) : (
+          <ul className="grid gap-2 max-h-[55vh] overflow-y-auto pr-1">
+            {history.map((entry, index) => {
+              const attackerLabel =
+                entry.attackerId === userId ? "自分" : opponentLabel ?? "相手";
+              return (
+                <li
+                  key={`${entry.roundCount}-${entry.turn}-${index}`}
+                  className="rounded-md border border-gray-600 bg-gray-900/70 p-3 text-sm"
+                >
+                  <div className="font-semibold text-gray-100">
+                    {entry.roundCount}回 {getTurnLabel(entry.turn)} ({attackerLabel}
+                    攻撃)
+                  </div>
+                  <div className="text-gray-300">
+                    電気椅子: {entry.electricChair} / 座った椅子: {entry.seatedChair}
+                  </div>
+                  <div
+                    className={`font-semibold ${
+                      entry.result === "shocked" ? "text-red-400" : "text-emerald-400"
+                    }`}
+                  >
+                    結果: {entry.result === "shocked" ? "感電" : "セーフ"}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <Button type="button" onClick={close} bgColor="bg-sky-600">
+          閉じる
+        </Button>
+      </div>
+    </InfoDialog>
+  );
+}

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -33,14 +33,18 @@ export function HistoryDialog({
             {history.map((entry, index) => {
               const attackerLabel =
                 entry.attackerId === userId ? "自分" : opponentLabel ?? "相手";
+              const seatedLabel =
+                entry.attackerId === userId ? opponentLabel ?? "相手" : "自分";
               return (
                 <li
                   key={`${entry.roundCount}-${entry.turn}-${index}`}
                   className="rounded-md border border-gray-600 bg-gray-900/70 p-3 text-sm"
                 >
                   <div className="font-semibold text-gray-100">
-                    {entry.roundCount}回 {getTurnLabel(entry.turn)} ({attackerLabel}
-                    攻撃)
+                    {entry.roundCount}回 {getTurnLabel(entry.turn)}
+                  </div>
+                  <div className="text-gray-300">
+                    電気を仕掛けた側: {attackerLabel} / 座った側: {seatedLabel}
                   </div>
                   <div className="text-gray-300">
                     電気椅子: {entry.electricChair} / 座った椅子: {entry.seatedChair}


### PR DESCRIPTION
## Summary
- CPU対戦画面のヘッダーにヒストリーボタンを追加
- InfoDialogパターンに沿ったHistoryDialogを新規作成
- #27で蓄積した履歴をモーダルで一覧表示（回数/表裏/攻撃者/電気椅子/着席椅子/結果）

## Test plan
- [x] `cd web && npx tsc --noEmit`
- [ ] `cd web && npm run lint`（next lint が `web/lint` を参照して失敗する既存問題あり）
- [ ] CPU対戦で複数ターン進行後にヒストリーから全履歴を閲覧できること（手動確認）
- [ ] setting/sitting フェーズ中でも開閉できること（手動確認）

Closes #28

🤖 Generated with Codex