### PR TITLE
ヒストリーの表示修正とプレイヤー別タブ追加

### DIFF
--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -40,7 +40,7 @@ export function HistoryDialog({
         : entry.result === "shocked";
 
       const chair = isAttacker ? entry.seatedChair : entry.electricChair;
-      const roleLabel = isAttacker ? "座った側" : "仕掛けた側";
+      const roleLabel = isAttacker ? "座った側" : "仕掛け側";
       const roleStyle = isAttacker
         ? "bg-sky-500/20 text-sky-200 border-sky-400/40"
         : "bg-orange-500/20 text-orange-200 border-orange-400/40";
@@ -105,7 +105,7 @@ export function HistoryDialog({
                   <div className="flex items-center gap-2 overflow-x-auto whitespace-nowrap text-sm">
                     <div className="min-w-fit font-semibold text-gray-100">{entry.roundLabel}</div>
                     <div
-                      className={`min-w-fit rounded-full border px-2 py-1 text-xs font-bold ${entry.roleStyle}`}
+                      className={`w-20 shrink-0 rounded-full border px-2 py-1 text-center text-xs font-bold ${entry.roleStyle}`}
                     >
                       {entry.roleLabel}
                     </div>

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -1,8 +1,8 @@
 import { InfoDialog } from "@/components/dialogs/InfoDialog";
 import { Button } from "@/components/buttons/Button";
 import { TurnHistory } from "@/types/room";
-import { Shield, Target, Zap } from "lucide-react";
-import { Ref } from "react";
+import { Shield, Zap } from "lucide-react";
+import { Ref, useMemo, useState } from "react";
 
 type HistoryDialogProps = {
   dialogRef: Ref<HTMLDialogElement>;
@@ -11,6 +11,8 @@ type HistoryDialogProps = {
   close: () => void;
   opponentLabel?: string;
 };
+
+type ActiveTab = "self" | "opponent";
 
 function getTurnLabel(turn: TurnHistory["turn"]) {
   return turn === "top" ? "表" : "裏";
@@ -23,6 +25,35 @@ export function HistoryDialog({
   close,
   opponentLabel,
 }: HistoryDialogProps) {
+  const [activeTab, setActiveTab] = useState<ActiveTab>("self");
+  const selfLabel = "自分";
+  const rivalLabel = opponentLabel ?? "相手";
+
+  const entries = useMemo(() => {
+    return history.map((entry, index) => {
+      const isSelfTab = activeTab === "self";
+      const isAttacker = isSelfTab
+        ? entry.attackerId === userId
+        : entry.attackerId !== userId;
+      const didSucceed = isAttacker
+        ? entry.result === "safe"
+        : entry.result === "shocked";
+
+      const actionLabel = isAttacker ? "座る椅子を選択" : "電気を仕掛ける椅子を選択";
+      const chair = isAttacker ? entry.seatedChair : entry.electricChair;
+      const actorLabel = isSelfTab ? selfLabel : rivalLabel;
+
+      return {
+        key: `${entry.roundCount}-${entry.turn}-${index}`,
+        roundLabel: `${entry.roundCount}回 ${getTurnLabel(entry.turn)}`,
+        actorLabel,
+        actionLabel,
+        chair,
+        didSucceed,
+      };
+    });
+  }, [activeTab, history, rivalLabel, userId]);
+
   return (
     <InfoDialog ref={dialogRef} borderColor="border-sky-500">
       <div className="grid gap-4">
@@ -30,72 +61,64 @@ export function HistoryDialog({
         {history.length === 0 ? (
           <p className="text-gray-300">まだ履歴はありません。</p>
         ) : (
-          <ul className="grid gap-2 max-h-[55vh] overflow-y-auto pr-1">
-            {history.map((entry, index) => {
-              const attackerLabel =
-                entry.attackerId === userId ? "自分" : opponentLabel ?? "相手";
-              const seatedLabel =
-                entry.attackerId === userId ? opponentLabel ?? "相手" : "自分";
-              const strategyResult =
-                entry.result === "shocked"
-                  ? "電気を仕掛けた側の作戦成功"
-                  : "座った側の回避成功";
-              return (
+          <>
+            <div className="inline-flex rounded-lg border border-gray-600 p-1 bg-gray-800/70">
+              <button
+                type="button"
+                onClick={() => setActiveTab("self")}
+                className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                  activeTab === "self"
+                    ? "bg-sky-500 text-white"
+                    : "text-gray-300 hover:bg-gray-700"
+                }`}
+              >
+                {selfLabel}
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab("opponent")}
+                className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                  activeTab === "opponent"
+                    ? "bg-sky-500 text-white"
+                    : "text-gray-300 hover:bg-gray-700"
+                }`}
+              >
+                {rivalLabel}
+              </button>
+            </div>
+            <ul className="grid gap-2 max-h-[55vh] overflow-y-auto pr-1">
+              {entries.map((entry) => (
                 <li
-                  key={`${entry.roundCount}-${entry.turn}-${index}`}
+                  key={entry.key}
                   className="rounded-md border border-gray-600 bg-gray-900/70 p-3"
                 >
                   <div className="flex items-center justify-between">
-                    <div className="font-semibold text-gray-100">
-                      {entry.roundCount}回 {getTurnLabel(entry.turn)}
-                    </div>
+                    <div className="font-semibold text-gray-100">{entry.roundLabel}</div>
                     <div
                       className={`text-xs font-bold px-2 py-1 rounded-full ${
-                        entry.result === "shocked"
-                          ? "bg-red-500/20 text-red-300"
-                          : "bg-emerald-500/20 text-emerald-300"
+                        entry.didSucceed
+                          ? "bg-emerald-500/20 text-emerald-300"
+                          : "bg-red-500/20 text-red-300"
                       }`}
                     >
-                      {strategyResult}
+                      {entry.didSucceed ? "成功" : "失敗"}
                     </div>
                   </div>
-                  <div className="grid grid-cols-2 gap-2 mt-3 text-sm">
-                    <div className="rounded border border-orange-400/40 bg-orange-950/30 p-2">
-                      <div className="flex items-center gap-1 text-orange-300 font-semibold">
-                        <Zap className="h-4 w-4" />
-                        電気を仕掛けた側
-                      </div>
-                      <div className="text-white font-bold">{attackerLabel}</div>
-                      <div className="text-gray-300 text-xs mt-1">
-                        狙い: 椅子{entry.electricChair}
-                      </div>
-                    </div>
-                    <div className="rounded border border-sky-400/40 bg-sky-950/30 p-2">
-                      <div className="flex items-center gap-1 text-sky-300 font-semibold">
+                  <div className="mt-2 rounded border border-gray-600/80 bg-gray-950/50 p-2 text-sm">
+                    <div className="flex items-center gap-1 text-sky-300 font-semibold">
+                      {entry.actionLabel === "座る椅子を選択" ? (
                         <Shield className="h-4 w-4" />
-                        座った側
-                      </div>
-                      <div className="text-white font-bold">{seatedLabel}</div>
-                      <div className="text-gray-300 text-xs mt-1">
-                        選択: 椅子{entry.seatedChair}
-                      </div>
+                      ) : (
+                        <Zap className="h-4 w-4" />
+                      )}
+                      {entry.actorLabel}: {entry.actionLabel}
                     </div>
-                  </div>
-                  <div className="mt-2 flex items-center gap-2 text-sm text-gray-300">
-                    <Target className="h-4 w-4 text-gray-400" />
-                    結果:
-                    <span
-                      className={`font-semibold ${
-                        entry.result === "shocked" ? "text-red-400" : "text-emerald-400"
-                      }`}
-                    >
-                      {entry.result === "shocked" ? "感電" : "セーフ"}
-                    </span>
+                    <div className="text-gray-300 text-xs mt-1">選択: 椅子{entry.chair}</div>
                   </div>
                 </li>
-              );
-            })}
-          </ul>
+              ))}
+            </ul>
+          </>
         )}
         <Button type="button" onClick={close} bgColor="bg-sky-600">
           閉じる

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -1,7 +1,6 @@
 import { InfoDialog } from "@/components/dialogs/InfoDialog";
 import { Button } from "@/components/buttons/Button";
 import { TurnHistory } from "@/types/room";
-import { Shield, Zap } from "lucide-react";
 import { Ref, useMemo, useState } from "react";
 
 type HistoryDialogProps = {
@@ -102,25 +101,19 @@ export function HistoryDialog({
                   key={entry.key}
                   className="rounded-md border border-gray-600 bg-gray-900/70 p-2"
                 >
-                  <div className="flex items-center gap-2 overflow-x-auto whitespace-nowrap text-sm">
-                    <div className="min-w-fit font-semibold text-gray-100">{entry.roundLabel}</div>
+                  <div className="grid grid-cols-[auto_auto_1fr_auto] items-center gap-2 text-sm">
+                    <div className="text-xs font-semibold text-gray-300">{entry.roundLabel}</div>
                     <div
                       className={`w-20 shrink-0 rounded-full border px-2 py-1 text-center text-xs font-bold ${entry.roleStyle}`}
                     >
                       {entry.roleLabel}
                     </div>
                     <div
-                      className={`inline-flex min-w-fit items-center gap-1 rounded-md border px-2 py-1 ${entry.chairStyle}`}
+                      className={`inline-flex min-w-0 items-center justify-center gap-1 rounded-md border px-2 py-1 ${entry.chairStyle}`}
                     >
-                      {entry.roleLabel === "座った側" ? (
-                        <Shield className="h-4 w-4" />
-                      ) : (
-                        <Zap className="h-4 w-4" />
-                      )}
                       <span className="text-[11px]">椅子</span>
-                      <span className="text-lg font-black leading-none">{entry.chair}</span>
+                      <span className="text-base font-black leading-none">{entry.chair}</span>
                     </div>
-                    <div className="ml-auto" />
                     <div
                       className={`w-20 shrink-0 text-center rounded-full border px-2 py-1 text-xs font-bold ${entry.resultStyle}`}
                     >

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -39,29 +39,27 @@ export function HistoryDialog({
         ? entry.result === "safe"
         : entry.result === "shocked";
 
-      const actionLabel = isAttacker ? "座る椅子を選択" : "電気を仕掛ける椅子を選択";
       const chair = isAttacker ? entry.seatedChair : entry.electricChair;
-      const actorLabel = isSelfTab ? selfLabel : rivalLabel;
       const roleLabel = isAttacker ? "座った側" : "仕掛けた側";
       const roleStyle = isAttacker
         ? "bg-sky-500/20 text-sky-200 border-sky-400/40"
         : "bg-orange-500/20 text-orange-200 border-orange-400/40";
-      const actionStyle = isAttacker ? "text-sky-300" : "text-orange-300";
       const chairStyle = isAttacker
         ? "border-sky-500/50 bg-sky-950/40 text-sky-200"
         : "border-orange-500/50 bg-orange-950/40 text-orange-200";
+      const resultStyle = didSucceed
+        ? "bg-emerald-500/20 text-emerald-300 border-emerald-400/40"
+        : "bg-red-500/20 text-red-300 border-red-400/40";
 
       return {
         key: `${entry.roundCount}-${entry.turn}-${index}`,
         roundLabel: `${entry.roundCount}回 ${getTurnLabel(entry.turn)}`,
-        actorLabel,
         roleLabel,
         roleStyle,
-        actionStyle,
-        actionLabel,
         chair,
         chairStyle,
         didSucceed,
+        resultStyle,
       };
     });
   }, [activeTab, history, rivalLabel, userId]);
@@ -102,44 +100,30 @@ export function HistoryDialog({
               {entries.map((entry) => (
                 <li
                   key={entry.key}
-                  className="rounded-md border border-gray-600 bg-gray-900/70 p-3"
+                  className="rounded-md border border-gray-600 bg-gray-900/70 p-2"
                 >
-                  <div className="flex items-center justify-between">
-                    <div className="font-semibold text-gray-100">{entry.roundLabel}</div>
+                  <div className="flex items-center gap-2 overflow-x-auto whitespace-nowrap text-sm">
+                    <div className="min-w-fit font-semibold text-gray-100">{entry.roundLabel}</div>
                     <div
-                      className={`text-xs font-bold px-2 py-1 rounded-full ${
-                        entry.didSucceed
-                          ? "bg-emerald-500/20 text-emerald-300"
-                          : "bg-red-500/20 text-red-300"
-                      }`}
+                      className={`min-w-fit rounded-full border px-2 py-1 text-xs font-bold ${entry.roleStyle}`}
                     >
-                      {entry.didSucceed ? "成功" : "失敗"}
+                      {entry.roleLabel}
                     </div>
-                  </div>
-                  <div className="mt-2 rounded border border-gray-600/80 bg-gray-950/50 p-2 text-sm">
-                    <div className="flex items-center justify-between gap-2">
-                      <div
-                        className={`rounded-full border px-2 py-1 text-xs font-bold ${entry.roleStyle}`}
-                      >
-                        {entry.roleLabel}
-                      </div>
-                      <div className={`text-xs font-semibold ${entry.actionStyle}`}>
-                        {entry.actionLabel}
-                      </div>
-                    </div>
-                    <div className="mt-2 flex items-center gap-1 font-semibold text-gray-100">
-                      {entry.actionLabel === "座る椅子を選択" ? (
+                    <div
+                      className={`inline-flex min-w-fit items-center gap-1 rounded-md border px-2 py-1 ${entry.chairStyle}`}
+                    >
+                      {entry.roleLabel === "座った側" ? (
                         <Shield className="h-4 w-4" />
                       ) : (
                         <Zap className="h-4 w-4" />
                       )}
-                      {entry.actorLabel}
+                      <span className="text-[11px]">椅子</span>
+                      <span className="text-lg font-black leading-none">{entry.chair}</span>
                     </div>
                     <div
-                      className={`mt-2 inline-flex items-baseline gap-1 rounded-md border px-2 py-1 ${entry.chairStyle}`}
+                      className={`min-w-fit rounded-full border px-2 py-1 text-xs font-bold ${entry.resultStyle}`}
                     >
-                      <span className="text-[11px]">選択した椅子</span>
-                      <span className="text-xl font-black leading-none">{entry.chair}</span>
+                      結果: {entry.didSucceed ? "成功" : "失敗"}
                     </div>
                   </div>
                 </li>

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -120,8 +120,9 @@ export function HistoryDialog({
                       <span className="text-[11px]">椅子</span>
                       <span className="text-lg font-black leading-none">{entry.chair}</span>
                     </div>
+                    <div className="ml-auto" />
                     <div
-                      className={`min-w-fit rounded-full border px-2 py-1 text-xs font-bold ${entry.resultStyle}`}
+                      className={`w-20 shrink-0 text-center rounded-full border px-2 py-1 text-xs font-bold ${entry.resultStyle}`}
                     >
                       結果: {entry.didSucceed ? "成功" : "失敗"}
                     </div>

--- a/web/features/room/components/dialogs/HistoryDialog.tsx
+++ b/web/features/room/components/dialogs/HistoryDialog.tsx
@@ -42,13 +42,25 @@ export function HistoryDialog({
       const actionLabel = isAttacker ? "座る椅子を選択" : "電気を仕掛ける椅子を選択";
       const chair = isAttacker ? entry.seatedChair : entry.electricChair;
       const actorLabel = isSelfTab ? selfLabel : rivalLabel;
+      const roleLabel = isAttacker ? "座った側" : "仕掛けた側";
+      const roleStyle = isAttacker
+        ? "bg-sky-500/20 text-sky-200 border-sky-400/40"
+        : "bg-orange-500/20 text-orange-200 border-orange-400/40";
+      const actionStyle = isAttacker ? "text-sky-300" : "text-orange-300";
+      const chairStyle = isAttacker
+        ? "border-sky-500/50 bg-sky-950/40 text-sky-200"
+        : "border-orange-500/50 bg-orange-950/40 text-orange-200";
 
       return {
         key: `${entry.roundCount}-${entry.turn}-${index}`,
         roundLabel: `${entry.roundCount}回 ${getTurnLabel(entry.turn)}`,
         actorLabel,
+        roleLabel,
+        roleStyle,
+        actionStyle,
         actionLabel,
         chair,
+        chairStyle,
         didSucceed,
       };
     });
@@ -105,15 +117,30 @@ export function HistoryDialog({
                     </div>
                   </div>
                   <div className="mt-2 rounded border border-gray-600/80 bg-gray-950/50 p-2 text-sm">
-                    <div className="flex items-center gap-1 text-sky-300 font-semibold">
+                    <div className="flex items-center justify-between gap-2">
+                      <div
+                        className={`rounded-full border px-2 py-1 text-xs font-bold ${entry.roleStyle}`}
+                      >
+                        {entry.roleLabel}
+                      </div>
+                      <div className={`text-xs font-semibold ${entry.actionStyle}`}>
+                        {entry.actionLabel}
+                      </div>
+                    </div>
+                    <div className="mt-2 flex items-center gap-1 font-semibold text-gray-100">
                       {entry.actionLabel === "座る椅子を選択" ? (
                         <Shield className="h-4 w-4" />
                       ) : (
                         <Zap className="h-4 w-4" />
                       )}
-                      {entry.actorLabel}: {entry.actionLabel}
+                      {entry.actorLabel}
                     </div>
-                    <div className="text-gray-300 text-xs mt-1">選択: 椅子{entry.chair}</div>
+                    <div
+                      className={`mt-2 inline-flex items-baseline gap-1 rounded-md border px-2 py-1 ${entry.chairStyle}`}
+                    >
+                      <span className="text-[11px]">選択した椅子</span>
+                      <span className="text-xl font-black leading-none">{entry.chair}</span>
+                    </div>
                   </div>
                 </li>
               ))}


### PR DESCRIPTION
## Summary
- ヒストリー表示で `attackerId` の解釈を修正し、仕掛けた側/座った側の表示名逆転バグを解消
- ヒストリーモーダルに `自分` / `相手` タブを追加
- タブ対象プレイヤーの行動（電気を仕掛ける/座る）と成否を見やすく表示

## Test plan
- [x] `cd web && npx tsc --noEmit`
- [ ] `cd web && npm run lint`（既存設定不整合により `Invalid project directory provided` で失敗）

Closes #33

🤖 Generated with Codex